### PR TITLE
Add Mobile Support

### DIFF
--- a/poll/poll.py
+++ b/poll/poll.py
@@ -220,6 +220,10 @@ class PollBlock(PollBase):
         else:
             return None
 
+    # Decorate the view in order to support multiple devices e.g. mobile
+    # See: https://openedx.atlassian.net/wiki/display/MA/Course+Blocks+API
+    # section 'View @supports(multi_device) decorator'
+    @XBlock.supports('multi_device')
     def student_view(self, context=None):
         """
         The primary view of the PollBlock, shown to students


### PR DESCRIPTION
Decorated the student view with the XBlocks_supports for multi_device
in order to solve the compatibility issue with mobile handheld devices.

Visually inspected, works as expected.

@stvstnfrd @caesar2164 @caseylitton 